### PR TITLE
マジックナンバーを使用しないように修正

### DIFF
--- a/src/Model/Post/PostReader.php
+++ b/src/Model/Post/PostReader.php
@@ -17,8 +17,7 @@ class PostReader
 	public function __construct(
 		Database $db,
 		Pagination $pagination
-	)
-	{
+	) {
 		$this->db = $db;
 		$this->pagination = $pagination;
 	}

--- a/src/Model/Post/PostReader.php
+++ b/src/Model/Post/PostReader.php
@@ -2,6 +2,7 @@
 namespace Model\Post;
 
 use Database\Database;
+use Pagination\Pagination;
 
 /**
  * 記事を読み込むモデル
@@ -11,10 +12,15 @@ use Database\Database;
 class PostReader
 {
 	private Database $db;
+	private Pagination $pagination;
 
-	public function __construct(Database $db)
+	public function __construct(
+		Database $db,
+		Pagination $pagination
+	)
 	{
 		$this->db = $db;
+		$this->pagination = $pagination;
 	}
 
 	/**
@@ -25,9 +31,11 @@ class PostReader
 	 */
 	public function select(int $page): array
 	{
-		$start = ($page - 1) * 3;
-		$stmt = $this->db->getConnection()->prepare('SELECT posts.id as post_id, post, user_id, name FROM posts INNER JOIN users ON posts.user_id = users.id ORDER BY posts.id DESC LIMIT :start, 3');
+		$display_posts = $this->pagination::DISPLAY_POSTS;
+		$start = ($page - 1) * $display_posts;
+		$stmt = $this->db->getConnection()->prepare('SELECT posts.id as post_id, post, user_id, name FROM posts INNER JOIN users ON posts.user_id = users.id ORDER BY posts.id DESC LIMIT :start, :display_posts');
 		$stmt->bindParam(':start', $start, \PDO::PARAM_INT);
+		$stmt->bindParam(':display_posts', $display_posts, \PDO::PARAM_INT);
 		$stmt->execute();
 		return $stmt->fetchAll();
 	}
@@ -41,10 +49,12 @@ class PostReader
 	 */
 	public function selectUserPosts(int $page, int $user_id): array
 	{
-		$start = ($page - 1) * 3;
-		$stmt = $this->db->getConnection()->prepare('SELECT posts.id as post_id, post, user_id, name FROM posts INNER JOIN users ON posts.user_id = users.id WHERE user_id = :user_id ORDER BY posts.id DESC LIMIT :start, 3');
+		$display_posts = $this->pagination::DISPLAY_POSTS;
+		$start = ($page - 1) * $display_posts;
+		$stmt = $this->db->getConnection()->prepare('SELECT posts.id as post_id, post, user_id, name FROM posts INNER JOIN users ON posts.user_id = users.id WHERE user_id = :user_id ORDER BY posts.id DESC LIMIT :start, :display_posts');
 		$stmt->bindParam(':user_id', $user_id, \PDO::PARAM_INT);
 		$stmt->bindParam(':start', $start, \PDO::PARAM_INT);
+		$stmt->bindParam(':display_posts', $display_posts, \PDO::PARAM_INT);
 		$stmt->execute();
 		return $stmt->fetchAll();
 	}

--- a/src/Pagination/Pagination.php
+++ b/src/Pagination/Pagination.php
@@ -8,6 +8,8 @@ namespace Pagination;
  */
 class Pagination
 {
+	public const DISPLAY_POSTS = 3;
+
 	/**
 	 * 総記事数を元に必要なページ数を計算
 	 *
@@ -16,6 +18,6 @@ class Pagination
 	 */
 	public function countPages(int $total_posts): int
 	{
-		return ceil($total_posts / 3);
+		return ceil($total_posts / self::DISPLAY_POSTS);
 	}
 }


### PR DESCRIPTION
## マジックナンバーに関する修正

- 現状、表示する記事数を3としているが、マジックナンバーを使わないようにしたい

- Pagination の修正
  - `public const DISPLAY_POSTS = 3;`
  - `return ceil($total_posts / self::DISPLAY_POSTS);`

- PostReader の修正
  - `Pagination::DISPLAY_POSTS` を使って書く